### PR TITLE
Be/feature/search

### DIFF
--- a/backend/src/main/java/com/bas/issuetracker/web/config/constants/SearchFilterConstants.java
+++ b/backend/src/main/java/com/bas/issuetracker/web/config/constants/SearchFilterConstants.java
@@ -1,0 +1,9 @@
+package com.bas.issuetracker.web.config.constants;
+
+public class SearchFilterConstants {
+    public static final String OPENED_ISSUE = "is:open";
+    public static final String CLOSED_ISSUE = "is:close";
+    public static final String AUTHOR_IS_ME = "author:@me";
+    public static final String ASSIGNEE_IS_ME = "assignee:@me";
+    public static final String COMMENT_BY_ME = "comment:@me";
+}

--- a/backend/src/main/java/com/bas/issuetracker/web/controller/IssueController.java
+++ b/backend/src/main/java/com/bas/issuetracker/web/controller/IssueController.java
@@ -52,5 +52,4 @@ public class IssueController {
     public void changeStateOfIssue(@RequestBody IssueOpenCloseRequest issueOpenCloseRequest) {
         issueService.changeStateOfIssue(issueOpenCloseRequest);
     }
-
 }

--- a/backend/src/main/java/com/bas/issuetracker/web/dto/search/SearchFilterData.java
+++ b/backend/src/main/java/com/bas/issuetracker/web/dto/search/SearchFilterData.java
@@ -1,0 +1,58 @@
+package com.bas.issuetracker.web.dto.search;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Objects;
+
+import static com.bas.issuetracker.web.config.constants.SearchFilterConstants.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SearchFilterData {
+
+    private boolean isOpen = true;
+    private boolean authorIsMe = false;
+    private boolean assigneeIsMe = false;
+    private boolean commentByMe = false;
+
+    public static SearchFilterData parse(String stringFilter) {
+        String[] filters = stringFilter.split(" ");
+        SearchFilterDataBuilder builder = new SearchFilterDataBuilder();
+        for (String filter : filters) {
+            switch (filter) {
+                case OPENED_ISSUE :
+                    builder.isOpen(true);
+                    break;
+                case CLOSED_ISSUE :
+                    builder.isOpen(false);
+                    break;
+                case AUTHOR_IS_ME :
+                    builder.authorIsMe(true);
+                    break;
+                case ASSIGNEE_IS_ME :
+                    builder.assigneeIsMe(true);
+                    break;
+                case COMMENT_BY_ME :
+                    builder.commentByMe(true);
+                    break;
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SearchFilterData that = (SearchFilterData) o;
+        return isOpen == that.isOpen && authorIsMe == that.authorIsMe && assigneeIsMe == that.assigneeIsMe && commentByMe == that.commentByMe;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isOpen, authorIsMe, assigneeIsMe, commentByMe);
+    }
+}

--- a/backend/src/main/java/com/bas/issuetracker/web/queries/IssueQuery.kt
+++ b/backend/src/main/java/com/bas/issuetracker/web/queries/IssueQuery.kt
@@ -16,3 +16,20 @@ inner JOIN user u ON u.id = i.author_id
 WHERE i.id = :issue_id AND i.author_id = u.id AND i.id = c.issue_id;  
 """
 
+const val SEARCH_ISSUES_BY_FILTER_BODY: String = """
+select i.id from issue i"""
+
+const val FILTER_PART_ASSIGNED_BY_ME: String = """
+inner join assigned a on i.id = a.issue_id and a.user_id = :assigned_user_id"""
+
+const val FILTER_PART_COMMENT_BY_ME: String = """
+inner join comment c on i.id = c.issue_id and c.author_id = :comment_author_id"""
+
+const val FILTER_PART_IS_OPENED: String = """
+where i.is_open = :is_open"""
+
+const val FILTER_PART_ISSUE_AUTHOR: String = """
+and i.author_id = :issue_author_id"""
+
+const val FILTER_PART_END_OF_QUERY: String = """
+group by i.id;"""

--- a/backend/src/main/java/com/bas/issuetracker/web/service/IssueService.java
+++ b/backend/src/main/java/com/bas/issuetracker/web/service/IssueService.java
@@ -3,6 +3,7 @@ package com.bas.issuetracker.web.service;
 import com.bas.issuetracker.web.dao.IssueDAO;
 import com.bas.issuetracker.web.dto.comment.CommentDTO;
 import com.bas.issuetracker.web.dto.issue.*;
+import com.bas.issuetracker.web.dto.search.SearchFilterData;
 import com.bas.issuetracker.web.exceptions.IssueException;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +31,10 @@ public class IssueService {
             booleanOpenOrClose = 1;
         }
         return issueDAO.findIssuesByOpenOrClose(booleanOpenOrClose);
+    }
+
+    public List<Integer> searchIssuesByFilter(SearchFilterData filterData, int userId) {
+        return issueDAO.findIssuesByFilter(filterData, userId);
     }
 
     public void createIssue(int userId, IssueRequestDTO issueRequestDTO) {

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -40,13 +40,13 @@ values (1, 1),
 insert into comment (content, issue_id, author_id, deletable)
 values ('comment 1', 1, 1, false),
        ('comment 2', 1, 1, true),
+       ('comment 3', 2, 1, false),
+       ('comment 4', 2, 1, true),
+       ('comment 5', 3, 1, false),
+       ('comment 6', 4, 1, false),
        ('comment 7', 1, 2, true),
        ('comment 8', 1, 2, true),
        ('comment 9', 1, 3, true),
        ('comment 10', 1, 3, true),
        ('comment 11', 1, 3, true),
-       ('comment 12', 1, 3, true),
-       ('comment 3', 2, 1, false),
-       ('comment 4', 2, 1, true),
-       ('comment 5', 3, 1, false),
-       ('comment 6', 4, 1, false);
+       ('comment 12', 1, 3, true);

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -37,16 +37,16 @@ values (1, 1),
        (8, 3),
        (7, 2);
 
-insert into comment (content, issue_id, author_id)
-values ('comment 1', 1, 1),
-       ('comment 2', 1, 1),
-       ('comment 3', 2, 1),
-       ('comment 4', 2, 1),
-       ('comment 5', 3, 1),
-       ('comment 6', 4, 1),
-       ('comment 7', 1, 2),
-       ('comment 8', 1, 2),
-       ('comment 9', 1, 3),
-       ('comment 10', 1, 3),
-       ('comment 11', 1, 3),
-       ('comment 12', 1, 3);
+insert into comment (content, issue_id, author_id, deletable)
+values ('comment 1', 1, 1, false),
+       ('comment 2', 1, 1, true),
+       ('comment 7', 1, 2, true),
+       ('comment 8', 1, 2, true),
+       ('comment 9', 1, 3, true),
+       ('comment 10', 1, 3, true),
+       ('comment 11', 1, 3, true),
+       ('comment 12', 1, 3, true),
+       ('comment 3', 2, 1, false),
+       ('comment 4', 2, 1, true),
+       ('comment 5', 3, 1, false),
+       ('comment 6', 4, 1, false);

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -35,7 +35,8 @@ values (1, 1),
        (8, 1),
        (3, 2),
        (8, 3),
-       (7, 2);
+       (3, 1),
+       (7, 1);
 
 insert into comment (content, issue_id, author_id, deletable)
 values ('comment 1', 1, 1, false),

--- a/backend/src/test/java/com/bas/issuetracker/web/dto/search/SearchFilterDataTest.java
+++ b/backend/src/test/java/com/bas/issuetracker/web/dto/search/SearchFilterDataTest.java
@@ -1,0 +1,47 @@
+package com.bas.issuetracker.web.dto.search;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.bas.issuetracker.web.config.constants.SearchFilterConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SearchFilterDataTest {
+
+    @Test
+    @DisplayName("문자열 검색필터를 객체로 변환할 수 있어야 합니다")
+    void testParse() {
+        String[] testcases = {
+                OPENED_ISSUE,
+                CLOSED_ISSUE,
+                OPENED_ISSUE + " " + AUTHOR_IS_ME,
+                OPENED_ISSUE + " " + ASSIGNEE_IS_ME,
+                OPENED_ISSUE + " " + COMMENT_BY_ME,
+                CLOSED_ISSUE + " " + AUTHOR_IS_ME,
+                CLOSED_ISSUE + " " + ASSIGNEE_IS_ME,
+                CLOSED_ISSUE + " " + COMMENT_BY_ME,
+                OPENED_ISSUE + " " + AUTHOR_IS_ME + " " + ASSIGNEE_IS_ME + " " + COMMENT_BY_ME,
+        };
+        SearchFilterData[] expecteds = {
+                new SearchFilterData(true, false, false, false),
+                new SearchFilterData(false, false, false, false),
+                new SearchFilterData(true, true, false, false),
+                new SearchFilterData(true, false, true, false),
+                new SearchFilterData(true, false, false, true),
+                new SearchFilterData(false, true, false, false),
+                new SearchFilterData(false, false, true, false),
+                new SearchFilterData(false, false, false, true),
+                new SearchFilterData(true, true, true, true),
+        };
+        testParseWithTestcase(testcases, expecteds);
+    }
+
+    private void testParseWithTestcase(String[] testcases, SearchFilterData[] expecteds) {
+        for (int i = 0; i < testcases.length; i++) {
+            String testcase = testcases[i];
+            SearchFilterData expected = expecteds[i];
+            SearchFilterData searchFilterData = SearchFilterData.parse(testcase);
+            assertThat(searchFilterData.equals(expected)).isTrue();
+        }
+    }
+}

--- a/backend/src/test/java/com/bas/issuetracker/web/service/IssueServiceTest.java
+++ b/backend/src/test/java/com/bas/issuetracker/web/service/IssueServiceTest.java
@@ -19,10 +19,16 @@ class IssueServiceTest {
     private IssueService issueService;
 
     @Test
-    @DisplayName("is:open author:@me assignee:@me comment:@me로 검색할 수 있어야 합니다")
+    @DisplayName("필터로 검색할 수 있어야 합니다")
     void testFindIssuesByFilter() {
-        String testcase = "is:open author:@me assignee:@me comment:@me";
-        Integer[] expected = {1, 2};
+        testFilterSearchByTestcase("is:open", new Integer[]{1, 2, 3, 5, 6, 7});
+        testFilterSearchByTestcase("is:open author:@me", new Integer[]{1, 2});
+        testFilterSearchByTestcase("is:open assignee:@me", new Integer[]{1, 2, 3, 7});
+        testFilterSearchByTestcase("is:open comment:@me", new Integer[]{1, 2, 3});
+        testFilterSearchByTestcase("is:open author:@me assignee:@me comment:@me", new Integer[]{1, 2});
+    }
+
+    private void testFilterSearchByTestcase(String testcase, Integer[] expected) {
         SearchFilterData searchFilterData = SearchFilterData.parse(testcase);
         List<Integer> issueIds = issueService.searchIssuesByFilter(searchFilterData, 1);
         assertThat(issueIds).contains(expected);

--- a/backend/src/test/java/com/bas/issuetracker/web/service/IssueServiceTest.java
+++ b/backend/src/test/java/com/bas/issuetracker/web/service/IssueServiceTest.java
@@ -1,0 +1,30 @@
+package com.bas.issuetracker.web.service;
+
+import com.bas.issuetracker.web.dto.search.SearchFilterData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class IssueServiceTest {
+
+    @Autowired
+    private IssueService issueService;
+
+    @Test
+    @DisplayName("is:open author:@me assignee:@me comment:@me로 검색할 수 있어야 합니다")
+    void testFindIssuesByFilter() {
+        String testcase = "is:open author:@me assignee:@me comment:@me";
+        Integer[] expected = {1, 2};
+        SearchFilterData searchFilterData = SearchFilterData.parse(testcase);
+        List<Integer> issueIds = issueService.searchIssuesByFilter(searchFilterData, 1);
+        assertThat(issueIds).contains(expected);
+    }
+}


### PR DESCRIPTION
검색기능 구현 완료했습니다
- 요구사항대로, 검색된 이슈에 대한 ID만 반환하는 메서드를 IssueService에 추가했습니다
- 검색필터로 검색하는 경우, 아래의 메서드를 사용하면 됩니다.
```java
public List<Integer> searchIssuesByFilter(SearchFilterData filterData, int userId) {
    return issueDAO.findIssuesByFilter(filterData, userId);
}
```
- 검색필터는 아래의 문자열을 조합해서 사용합니다
```java
public class SearchFilterConstants {
    public static final String OPENED_ISSUE = "is:open";
    public static final String CLOSED_ISSUE = "is:close";
    public static final String AUTHOR_IS_ME = "author:@me";
    public static final String ASSIGNEE_IS_ME = "assignee:@me";
    public static final String COMMENT_BY_ME = "comment:@me";
}
```